### PR TITLE
fix: correct documentation typos and broken links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ Run local versions of the APIs to avoid rate limiting from the hosted versions.
    cd api
    ```
 
-2. Edit the `src\Helldivers-2-API\appsettings.json` to your likig. Make sure you set the `ValidAudiences` to `["*"]` or else you will have problems. [More info](https://github.com/helldivers-2/api/blob/master/docs/containers.md#configuring-api-keys-for-the-self-hosted-version)
+2. Edit the `src/Helldivers-2-API/appsettings.json` to your liking. Make sure you set the `ValidAudiences` to `["*"]` or else you will have problems. [More info](https://github.com/helldivers-2/api/blob/master/docs/containers.md#configuring-api-keys-for-the-self-hosted-version)
 
    ```json
     {
@@ -51,7 +51,7 @@ Run local versions of the APIs to avoid rate limiting from the hosted versions.
     docker compose up -d helldivers-api 
     ```
 
-### [DiveHarder](https://github.com/helldivers-2/api)
+### [DiveHarder](https://github.com/helldivers-2/diveharder_api.py)
 
 1. Clone the repo and cd into it.
 

--- a/docs/links.md
+++ b/docs/links.md
@@ -9,5 +9,5 @@ A list of links that may come in handy when using this lib or other parts of the
 - [PyPi project](https://pypi.org/project/helldivepy/)
 - [DiveHarder](https://github.com/helldivers-2/diveharder_api.py)
 - [Community API](https://github.com/helldivers-2/api)
-- [Comuunity Github](https://github.com/helldivers-2/)
+- [Community Github](https://github.com/helldivers-2/)
 - [API discussion Discord](https://discord.gg/MThYGMCqgp)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ docs = [
 [project.urls]
 Homepage = "https://github.com/ajxd2/helldive.py"
 Repository = "https://github.com/ajxd2/helldive.py"
-Documentation = "https://github.com/ajxd2/helldive.py#readme"
+Documentation = "https://helldivepy.ajxd2.dev"
 
 [build-system]
 requires = ["hatchling"]


### PR DESCRIPTION
## Summary
- Fix "Comuunity" typo → "Community" in `docs/links.md`
- Fix DiveHarder section heading link in `CONTRIBUTING.md` (was pointing to Community API repo instead of DiveHarder repo)
- Fix Windows-style backslash path separator and typo in `CONTRIBUTING.md`
- Fix `Documentation` URL in `pyproject.toml` to point to `https://helldivepy.ajxd2.dev` instead of the GitHub README

## Test plan
- [x] Verify all links resolve correctly in browser
- [x] Verify docs site URL is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)