### PR TITLE
fix: code quality improvements across library

### DIFF
--- a/helldivepy/api/dispatches.py
+++ b/helldivepy/api/dispatches.py
@@ -20,7 +20,7 @@ class DispatchModule(BaseApiModule):
 
     def get_dispatches(self, old_to_new: bool = True) -> typing.List[models.Dispatch]:
         """
-        Gets the information about the current war.
+        Gets all dispatches (in-game news), ordered by publish date.
         """
 
         # Sort the dispatches by published date
@@ -34,7 +34,7 @@ class DispatchModule(BaseApiModule):
 
     def get_dispatch(self, dispatch_id: int) -> models.Dispatch:
         """
-        Gets the information about the current war.
+        Gets a single dispatch by its ID.
         """
         # Get the dispatch by the ID/Index
         data = self.get("community", "api", "v1", "dispatches", str(dispatch_id))

--- a/helldivepy/api/steam.py
+++ b/helldivepy/api/steam.py
@@ -20,7 +20,7 @@ class SteamModule(BaseApiModule):
 
     def get_all_steam_news(self) -> typing.List[models.SteamNews]:
         """
-        Gets the information about the current war.
+        Gets all Steam news/patch notes for the game.
         """
         data = self.get("community", "api", "v1", "steam")
 
@@ -28,7 +28,7 @@ class SteamModule(BaseApiModule):
 
     def get_steam_news(self, gid: str) -> models.SteamNews:
         """
-        Gets the information about the current war.
+        Gets a single Steam news item by its GID.
         """
         data = self.get("community", "api", "v1", "steam", gid)
         return models.SteamNews(**data)

--- a/helldivepy/api_client.py
+++ b/helldivepy/api_client.py
@@ -8,7 +8,7 @@ import helldivepy.api as modules
 
 
 def retry_adapter(
-    backoff_factor: float, retries: int, extra_retry_codes: list | None = None
+    backoff_factor: float, retries: int, extra_retry_codes: list[int] | None = None
 ) -> HTTPAdapter:
     """Configures an HTTP adapter with retries and backoff."""
     if extra_retry_codes is None:
@@ -28,7 +28,7 @@ def set_logger(debug: bool) -> logging.Logger:
     from rich.logging import RichHandler
 
     logger = logging.getLogger(__name__)
-    logger.level = logging.DEBUG if debug else 5000
+    logger.level = logging.DEBUG if debug else logging.CRITICAL + 1
     if debug:
         logger.addHandler(
             RichHandler(

--- a/helldivepy/utils.py
+++ b/helldivepy/utils.py
@@ -2,6 +2,14 @@ import re
 from helldivepy.constants import FACTIONS
 import helldivepy.enums as enums
 
+# HDML tag IDs used by the DiveHarder Markup Language
+_HDML_TAG_BOLD = "3"
+_HDML_TAG_YELLOW = "1"
+
+# Compiled once at import time for performance
+_HDML_INLINE_PATTERN = re.compile(r"<i=(\d+)>(.*?)<\/i(?:=\1)?>")
+_HDML_TAG_STRIP_PATTERN = re.compile(r"<\/?i(?:=\d+)?>")
+
 
 def hdml_to_md(text: str) -> str:
     """
@@ -16,19 +24,18 @@ def hdml_to_md(text: str) -> str:
 
     """
 
-    pattern = r"<i=(\d+)>(.*?)<\/i(?:=\1)?>"
-    matches = re.findall(pattern, text)
+    matches = _HDML_INLINE_PATTERN.findall(text)
 
     modified_text = text
     for match in matches:
-        if match[0] == "3":
+        if match[0] == _HDML_TAG_BOLD:
             modified_text = modified_text.replace(match[1], f"[b]{match[1]}[/b]")
-        elif match[0] == "1":
+        elif match[0] == _HDML_TAG_YELLOW:
             modified_text = modified_text.replace(
                 match[1], f"[yellow]{match[1]}[/yellow]"
             )
 
-    modified_text = re.sub(r"<\/?i(?:=\d+)?>", "", modified_text)
+    modified_text = _HDML_TAG_STRIP_PATTERN.sub("", modified_text)
 
     return modified_text
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -79,7 +79,7 @@ plugins:
       default_handler: python
       handlers:
         python:
-          paths: [./] 
+          paths: [helldivepy]
           options:
             members: true
             members_order: source

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "requests>=2.32.3",
     "fire>=0.7.0",
     "rich>=13.9.4,<15.0.0",
-    "pydantic>=2.10.3",
+    "pydantic>=2.10.3,<3.0.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- **`utils.py`**: Compile HDML regex patterns at module level instead of on every function call; replace magic number tag IDs (`"1"`, `"3"`) with named constants `_HDML_TAG_BOLD` / `_HDML_TAG_YELLOW`
- **`api_client.py`**: Replace undocumented magic log level `5000` with `logging.CRITICAL + 1`; tighten `extra_retry_codes` type hint from `list | None` → `list[int] | None`
- **`dispatches.py`**: Fix copy-pasted `"Gets the information about the current war."` docstrings in `get_dispatches()` and `get_dispatch()`
- **`steam.py`**: Same docstring fix for `get_all_steam_news()` and `get_steam_news()`
- **`mkdocs.yml`**: Narrow autodoc `paths` from `./` (entire repo) to `helldivepy` (just the package)
- **`pyproject.toml`**: Add `pydantic<3.0.0` upper bound to protect against future breaking changes

## Test plan
- [ ] Verify `from helldivepy.utils import hdml_to_md; hdml_to_md("<i=3>test</i>")` returns `"[b]test[/b]"`
- [ ] Verify `ApiClient` logger is silent at level `CRITICAL + 1` when `debug=False`
- [ ] Verify `mkdocs build` succeeds with narrowed autodoc path

🤖 Generated with [Claude Code](https://claude.com/claude-code)