### PR TITLE
fix(api): fix caching off-by-one, space station URL, singleton warning

### DIFF
--- a/helldivepy/api/planets.py
+++ b/helldivepy/api/planets.py
@@ -41,10 +41,9 @@ class PlanetsModule(BaseApiModule):
             models.Planet: The planet object
         """
         if cached:
-            if len(self._planets) < index:
+            if index >= len(self._planets):
                 self.logger.warning(f"Planet {index} not cached. Fetching from API.")
                 self.get_planets()
-                return self._planets[index]
             return self._planets[index]
         data = self.get("community", "api", "v1", "planets", str(index))
         return models.Planet(**data)

--- a/helldivepy/api/space_stations.py
+++ b/helldivepy/api/space_stations.py
@@ -20,15 +20,15 @@ class SpaceStationModule(BaseApiModule):
         data = self.get("community", "api", "v1", "space-stations")
         return [models.SpaceStation(**item) for item in data]
 
-    def get_space_station(self, index: int) -> Optional[models.SpaceStation]:
+    def get_space_station(self, station_id: int) -> Optional[models.SpaceStation]:
         """
         Retrieves a space station by its ID.
 
         Args:
-            index (int): The ID of the space station.
+            station_id (int): The ID of the space station.
 
         Returns:
             Optional[SpaceStation]: The space station object if found, or None.
         """
-        data = self.get("community", "api", "v1", "space", "stations", str(index))
+        data = self.get("community", "api", "v1", "space-stations", str(station_id))
         return models.SpaceStation(**data) if data else None

--- a/helldivepy/api_client.py
+++ b/helldivepy/api_client.py
@@ -1,4 +1,5 @@
 import logging
+import warnings
 import requests
 from requests.adapters import HTTPAdapter, Retry
 from helldivepy.constants import OFFICIAL_DIVEHARDER_URL, OFFICIAL_COMMUNITY_URL
@@ -65,6 +66,12 @@ class ApiClient:
         if cls._instance is None:
             cls._instance = super(ApiClient, cls).__new__(cls)
             cls._instance.__init__(*args, **kwargs)
+        else:
+            warnings.warn(
+                "ApiClient is a singleton. The existing instance will be returned; "
+                "new constructor arguments are ignored.",
+                stacklevel=2,
+            )
         return cls._instance
 
     @classmethod


### PR DESCRIPTION
## Summary
- **`planets.py`**: Fix inverted cache check — `len(self._planets) < index` was `False` when `index == len(self._planets)`, so the cache was assumed valid and `self._planets[index]` raised `IndexError`. Corrected to `index >= len(self._planets)`.
- **`space_stations.py`**: Fix `get_space_station()` URL path from `("space", "stations", id)` → `("space-stations", id)` to be consistent with `get_space_stations()` which correctly uses the hyphenated form. Also rename parameter `index` → `station_id` to match the docstring and other modules' conventions.
- **`api_client.py`**: Emit `warnings.warn()` when `ApiClient()` is called a second time — previously new constructor arguments were silently ignored, which is a footgun when trying to reconfigure the client.

## Test plan
- [ ] `client.planets.get_planet(0, cached=True)` returns planet 0 without IndexError
- [ ] `client.planets.get_planet(500, cached=True)` triggers a re-fetch warning and returns correct planet
- [ ] `client.space_stations.get_space_station(1)` makes request to `/api/v1/space-stations/1` (not `/space/stations/1`)
- [ ] Calling `ApiClient(...)` a second time prints a `UserWarning`

🤖 Generated with [Claude Code](https://claude.com/claude-code)